### PR TITLE
fix: resolve TypeScript imports in ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,9 @@ export default defineConfig([
       'n/no-process-exit': 'off',
       'n/no-unsupported-features': 'off',
       'n/no-unpublished-require': 'off',
+      'n/no-missing-import': ['error', {
+        typescriptExtensionMap: [['.ts', '.js'], ['.tsx', '.js']]
+      }],
       'security/detect-non-literal-fs-filename': 'off',
       'security/detect-unsafe-regex': 'error',
       'security/detect-buffer-noassert': 'error',


### PR DESCRIPTION
The grouped dev-dependency update raises eslint-plugin-n to v18, whose no-missing-import rule needs the repository’s .js-to-.ts import mapping. Configure the supported TypeScript extension map so lint accepts NodeNext TypeScript imports. Verified with npm ci and npm run lint in Node 24.